### PR TITLE
Fixing error in integrated term

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,11 +29,11 @@
     // General formatting
     "files.trimTrailingWhitespace": true,
     "[cpp]": {
-        "editor.formatOnPaste": false,
+        "editor.formatOnPaste": true,
         "editor.formatOnSave": true
     },
     "[python]": {
-        "editor.formatOnPaste": false,
+        "editor.formatOnPaste": true,
         "editor.formatOnSave": true
     },
     "files.associations": {

--- a/exoplanet/gp/celerite_test.py
+++ b/exoplanet/gp/celerite_test.py
@@ -153,7 +153,4 @@ def test_integrated(seed=1234):
     kernel = terms.IntegratedTerm(kernel, dt)
     a = kernel.get_celerite_matrices(x, diag)[0].eval()
     k0 = kernel.value(tt.zeros(1)).eval()
-    print(a, k0 + diag)
     assert np.allclose(a, k0 + diag)
-
-    assert 0

--- a/exoplanet/gp/celerite_test.py
+++ b/exoplanet/gp/celerite_test.py
@@ -136,7 +136,6 @@ def test_gp(celerite_kernel, seed=1234):
     assert np.allclose(loglike, celerite_loglike)
 
 
-@pytest.mark.skip(reason="WIP")
 def test_integrated(seed=1234):
     np.random.seed(seed)
     x = np.sort(np.random.uniform(0, 100, 100))

--- a/exoplanet/gp/terms.py
+++ b/exoplanet/gp/terms.py
@@ -317,7 +317,7 @@ class IntegratedTerm(Term):
 
         # Real part
         cd = cr * dt
-        delta_diag = 2 * tt.sum(cd + tt.exp(-cd) - 1)
+        delta_diag = tt.sum(2 * ar * (cr * dt - tt.sinh(cd)) / cd ** 2)
 
         # Complex part
         cd = c * dt
@@ -327,14 +327,16 @@ class IntegratedTerm(Term):
         c2pd2 = c2 + d2
         C1 = a * (c2 - d2) + 2 * b * c * d
         C2 = b * (c2 - d2) - 2 * a * c * d
-        norm = 1.0 / (dt * c2pd2) ** 2
-        delta_diag += tt.sum(
-            2
-            * norm
-            * (
-                (a * c + b * d) * c2pd2 * dt
-                - tt.sinh(cd) * (C1 * tt.cos(dd) + C2 * tt.sin(dd))
+        norm = (dt * c2pd2) ** 2
+        sinh = tt.sinh(cd)
+        cosh = tt.cosh(cd)
+        delta_diag += 2 * tt.sum(
+            (
+                C2 * cosh * tt.sin(dd)
+                - C1 * sinh * tt.cos(dd)
+                + (a * c + b * d) * dt * c2pd2
             )
+            / norm
         )
 
         new_diag = diag + delta_diag

--- a/exoplanet/gp/terms.py
+++ b/exoplanet/gp/terms.py
@@ -356,12 +356,12 @@ class IntegratedTerm(Term):
         dd = d * self.delta
         c2 = c ** 2
         d2 = d ** 2
-        factor = 1.0 / (self.delta * (c2 + d2)) ** 2
+        factor = 2.0 / (self.delta * (c2 + d2)) ** 2
         cos_term = tt.cosh(cd) * tt.cos(dd) - 1
         sin_term = tt.sinh(cd) * tt.sin(dd)
 
-        C1 = 2 * (a * (c2 - d2) + 2 * b * c * d)
-        C2 = 2 * (b * (c2 - d2) - 2 * a * c * d)
+        C1 = a * (c2 - d2) + 2 * b * c * d
+        C2 = b * (c2 - d2) - 2 * a * c * d
 
         coeffs += [
             factor * (C1 * cos_term - C2 * sin_term),

--- a/paper/exoplanet.tex
+++ b/paper/exoplanet.tex
@@ -807,22 +807,23 @@ k(\tau) &= \tfrac{1}{2}\left[(a + i\,b)\,\exp\left(-(c+i\,d)\,\tau\right)+ (a - 
 \end{align}
 This results in a time-integrated kernel for $\tau \ge \Delta$ given by
 \begin{equation}
-k_\Delta(\tau) = A\exp\left(-c\,\tau\right)\cos\left(d\,\tau\right) + B\exp\left(-c\,\tau\right)\sin\left(d\,\tau\right).
+k_{\Delta\le\tau}(\tau) = A\exp\left(-c\,\tau\right)\cos\left(d\,\tau\right) + B\exp\left(-c\,\tau\right)\sin\left(d\,\tau\right).
 \end{equation}
 while for $0 \le \tau < \Delta$,
-\begin{align}
-k_\Delta(\tau) &= A\exp\left(-c\,\tau\right)\cos\left(d\,\tau\right) + B\exp\left(-c\,\tau\right)\sin\left(d\,\tau\right) \nonumber\\
-&+  \frac{2}{ \Delta^2(c^2+d^2)^2} \left\{(ac+bd)(c^2+d^2)(\Delta-\tau)\right. \nonumber \\
-&+\left.  \sinh(c(\tau-\Delta)) \left(C_1\cos(d(\Delta-\tau)) +C_2 \sin(d(\Delta-\tau))\right) \right\}.
-\end{align}
+\begin{eqnarray}
+k_{\Delta>\tau}(\tau) &=& k_{\Delta\le\tau}(\tau) + 2\,\left[
+  - C_1\,\sinh(c\,\Delta-c\,\tau)\,\cos(d\,\Delta-d\,\tau) \right. \nonumber\\
+&&  + C_2\,\cosh(c\,\Delta-c\,\tau)\,\sin(d\,\Delta-d\,\tau) \nonumber \\
+&&  \left. + (a\,c + b\,d)\,(c^2 + d^2)\,(\Delta-\tau)\right] / [\Delta\,(c^2+d^2)]^2
+\end{eqnarray}
 Note that in the limit of $b = d = 0$, this kernel reverts to the real kernel.
 As with the real case, the kernel is only semi-separable when exposures
 do not overlap in time, i.e. $\vert t_i - t_j \vert > \Delta$ for all $i,j$, while the diagonal
 components of the covariance matrix require adding the extra term:
-\begin{equation}
-\frac{2}{ \Delta^2(c^2+d^2)^2} \left\{(ac+bd)(c^2+d^2)\Delta
--\sinh(c\Delta) \left(C_1\cos(d\Delta) +C_2 \sin(d\Delta)\right) \right\}.
-\end{equation}
+\begin{eqnarray}
+  \frac{2\,\left[
+    - C_1\,\sinh(c\,\Delta)\,\cos(d\,\Delta) + C_2\,\cosh(c\,\Delta)\,\sin(d\,\Delta) + (a\,c + b\,d)\,(c^2 + d^2)\,\Delta\right]}{[\Delta\,(c^2+d^2)]^2}
+\end{eqnarray}
 As with the real case, the power spectrum of the time-integrated kernel simply
 requires multiplication by the sinc-squared function:
 \begin{equation}

--- a/paper/proofs/celerite-integral.ipynb
+++ b/paper/proofs/celerite-integral.ipynb
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -527,7 +527,7 @@
        "Piecewise((2*sin(dt*omega/2)/(dt*omega), Ne(dt*omega, 0)), (1, True))"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -573,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -582,7 +582,7 @@
        "(2*cr*dt*exp(cr*tau) - 2*cr*tau*exp(cr*tau) + exp(cr*(-dt + 2*tau)) - 2 + exp(-cr*dt))*exp(-cr*tau)/(cr**2*dt**2)"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -607,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -616,7 +616,7 @@
        "0"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -635,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -644,7 +644,7 @@
        "(2*dt*(a*c**3 + a*c*d**2 + b*c**2*d + b*d**3)*exp(c*(2*dt + 2*tau)) - 2*tau*(a*c**3 + a*c*d**2 + b*c**2*d + b*d**3)*exp(c*(2*dt + 2*tau)) + 2*(-a*c**2*cos(d*tau) + 2*a*c*d*sin(d*tau) + a*d**2*cos(d*tau) - b*c**2*sin(d*tau) - 2*b*c*d*cos(d*tau) + b*d**2*sin(d*tau))*exp(c*(2*dt + tau)) + (a*c**2*cos(d*(dt - tau)) - 2*a*c*d*sin(d*(dt - tau)) - a*d**2*cos(d*(dt - tau)) + b*c**2*sin(d*(dt - tau)) + 2*b*c*d*cos(d*(dt - tau)) - b*d**2*sin(d*(dt - tau)))*exp(c*(dt + 3*tau)) + (a*c**2*cos(d*(dt + tau)) - 2*a*c*d*sin(d*(dt + tau)) - a*d**2*cos(d*(dt + tau)) + b*c**2*sin(d*(dt + tau)) + 2*b*c*d*cos(d*(dt + tau)) - b*d**2*sin(d*(dt + tau)))*exp(c*(dt + tau)))*exp(-2*c*(dt + tau))/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -658,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -667,7 +667,7 @@
        "0"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -694,6 +694,133 @@
    "metadata": {},
    "source": [
     "And now, finally, I think we're done."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What about the diagonal?\n",
+    "\n",
+    "By default, the diagonal terms in a celerite model are $\\sum a_j$.\n",
+    "In this case, that would be $A$, but that would be wrong because $\\tau = 0 < \\Delta$.\n",
+    "Let's work out what extra term should be added to the diagonal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delta = sm.simplify(ktest.subs([(tau, 0)]) - A)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-a*c**2*exp(2*c*dt) + a*c**2 + a*d**2*exp(2*c*dt) - a*d**2 - 2*b*c*d*exp(2*c*dt) + 2*b*c*d)*exp(-c*dt)/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm.simplify(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(sm.cos(dt*d)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-2*a*c*d*exp(2*c*dt) - 2*a*c*d + b*c**2*exp(2*c*dt) + b*c**2 - b*d**2*exp(2*c*dt) - b*d**2)*exp(-c*dt)/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm.simplify(sm.poly(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(1), sm.sin(dt*d)).coeff_monomial(sm.sin(dt*d)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2*(a*c + b*d)/(dt*(c**2 + d**2))"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm.simplify(sm.poly(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(1), sm.sin(dt*d)).coeff_monomial(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "C1 = (a*c**2 - a*d**2 + 2*b*c*d)\n",
+    "C2 = (b*c**2 - b*d**2 - 2*a*c*d)\n",
+    "norm = dt**2 * (c**2 + d**2)**2\n",
+    "sinh = (sm.exp(c*dt) - sm.exp(-c*dt))/2\n",
+    "cosh = (sm.exp(c*dt) + sm.exp(-c*dt))/2\n",
+    "delta_test = 2 * (C2 * cosh * sm.sin(d*dt) - C1 * sinh * sm.cos(d*dt) + (a*c + b*d) * dt * (c**2 + d**2)) / norm\n",
+    "\n",
+    "sm.simplify(delta.expand(trig=True, complex=True) - delta_test.expand(trig=True, complex=True))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "a*(2*c*dt*exp(c*dt) - exp(2*c*dt) + 1)*exp(-c*dt)/(c**2*dt**2)"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm.simplify(delta_test.subs([(d, 0), (b, 0)]))"
    ]
   },
   {

--- a/paper/proofs/celerite-integral.ipynb
+++ b/paper/proofs/celerite-integral.ipynb
@@ -693,6 +693,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "This corresponds to adding a function to the kernel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "delta = sm.simplify(ktest.expand(trig=True) - (A * sm.exp(-c*tau) * sm.cos(d*tau) + B * sm.exp(-c*tau) * sm.sin(d*tau)))\n",
+    "\n",
+    "C1 = (a*c**2 - a*d**2 + 2*b*c*d)\n",
+    "C2 = (b*c**2 - b*d**2 - 2*a*c*d)\n",
+    "sinh = (sm.exp(c*(dt - tau)) - sm.exp(-c*(dt - tau)))/2\n",
+    "cosh = (sm.exp(c*(dt - tau)) + sm.exp(-c*(dt - tau)))/2\n",
+    "norm = dt**2 * (c**2 + d**2)**2\n",
+    "\n",
+    "delta_test = 2 * (C2 * cosh * sm.sin(d*(dt-tau)) - C1 * sinh * sm.cos(d*(dt-tau)) + (a*c + b*d) * (dt-tau) * (c**2 + d**2)) / norm\n",
+    "sm.simplify(delta.expand(trig=True) - delta_test.expand(trig=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "And now, finally, I think we're done."
    ]
   },
@@ -709,31 +745,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
     "delta = sm.simplify(ktest.subs([(tau, 0)]) - A)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(-a*c**2*exp(2*c*dt) + a*c**2 + a*d**2*exp(2*c*dt) - a*d**2 - 2*b*c*d*exp(2*c*dt) + 2*b*c*d)*exp(-c*dt)/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sm.simplify(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(sm.cos(dt*d)))"
    ]
   },
   {
@@ -744,7 +760,7 @@
     {
      "data": {
       "text/plain": [
-       "(-2*a*c*d*exp(2*c*dt) - 2*a*c*d + b*c**2*exp(2*c*dt) + b*c**2 - b*d**2*exp(2*c*dt) - b*d**2)*exp(-c*dt)/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
+       "(-a*c**2*exp(2*c*dt) + a*c**2 + a*d**2*exp(2*c*dt) - a*d**2 - 2*b*c*d*exp(2*c*dt) + 2*b*c*d)*exp(-c*dt)/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
       ]
      },
      "execution_count": 29,
@@ -753,7 +769,7 @@
     }
    ],
    "source": [
-    "sm.simplify(sm.poly(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(1), sm.sin(dt*d)).coeff_monomial(sm.sin(dt*d)))"
+    "sm.simplify(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(sm.cos(dt*d)))"
    ]
   },
   {
@@ -764,7 +780,7 @@
     {
      "data": {
       "text/plain": [
-       "2*(a*c + b*d)/(dt*(c**2 + d**2))"
+       "(-2*a*c*d*exp(2*c*dt) - 2*a*c*d + b*c**2*exp(2*c*dt) + b*c**2 - b*d**2*exp(2*c*dt) - b*d**2)*exp(-c*dt)/(dt**2*(c**4 + 2*c**2*d**2 + d**4))"
       ]
      },
      "execution_count": 30,
@@ -773,7 +789,7 @@
     }
    ],
    "source": [
-    "sm.simplify(sm.poly(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(1), sm.sin(dt*d)).coeff_monomial(1))"
+    "sm.simplify(sm.poly(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(1), sm.sin(dt*d)).coeff_monomial(sm.sin(dt*d)))"
    ]
   },
   {
@@ -784,10 +800,30 @@
     {
      "data": {
       "text/plain": [
-       "0"
+       "2*(a*c + b*d)/(dt*(c**2 + d**2))"
       ]
      },
      "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sm.simplify(sm.poly(sm.poly(delta, sm.cos(dt*d)).coeff_monomial(1), sm.sin(dt*d)).coeff_monomial(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
@ericagol: there was a missing `cosh` in the derivation of the integrated term for `tau < Delta` in the manuscript (it was right in the code!), but I found it when deriving the correction for the diagonal of the celerite matrix (which hadn't been implemented correctly before).